### PR TITLE
Support DIR and PREFIX options

### DIFF
--- a/lib/tasks/translator_tasks.rake
+++ b/lib/tasks/translator_tasks.rake
@@ -9,6 +9,7 @@ namespace :translator do
     missing = translator.export_keys
     if missing.length > 0
       filename = "translate_#{from}_to_#{to}.txt"
+      filename = "#{Translator::Translator.prefix}_#{filename}" if Translator::Translator.prefix
       File.open(filename, 'w') do |file_handler|
         file_handler.write missing
       end
@@ -20,11 +21,27 @@ namespace :translator do
 
   desc 'Import missing translations for a specific locale'
   task import_keys: :environment do
-    next unless Translator::Translator.check_params 'FROM', 'TO', 'FILE'
-    file_handler = File.open Translator::Translator.file
-    translator = Translator::Translator.instance
-    translator.import_keys file_handler.read
-    translator.write_locale_file
+    next unless Translator::Translator.check_params 'FROM', 'TO'
+
+    from = Translator::Translator.from
+    to = Translator::Translator.to
+    
+    filename = if Translator::Translator.file
+      Translator::Translator.file
+    else
+      possible_filename = "translate_#{from}_to_#{to}.txt"
+      possible_filename = "#{Translator::Translator.prefix}_#{possible_filename}" if Translator::Translator.prefix
+      possible_filename if File.exist?(possible_filename)
+    end
+    
+    if filename
+      file_handler = File.open filename
+      translator = Translator::Translator.instance
+      translator.import_keys file_handler.read
+      translator.write_locale_file
+    else
+      Translator::Translator.check_params 'FROM', 'TO', 'FILE'
+    end
   end
 
   desc 'submits the translations to gengo'

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -14,7 +14,7 @@ module Translator
       @from = options[:from]
       @to = options[:to]
       @comments = options[:comments]
-      @directory = options[:directory] || "config/locales/multilingual"
+      @directory = options[:directory] || Translator.dir || "config/locales/multilingual"
       @orders = self.class.read_orders
     end
 
@@ -122,7 +122,7 @@ module Translator
         Rails.root.join '.in_progress_translations'
       end
 
-      %w(FROM TO FILE).each do |param|
+      %w(FROM TO FILE DIR PREFIX).each do |param|
 
         define_method param.downcase do
           ENV[param]
@@ -133,7 +133,7 @@ module Translator
       def check_params *params
         all_are_present = params.all? { |param| ENV[param].present? }
         unless all_are_present
-          STDERR.puts "usage example: rake translator FROM=en TO=fr FILE=en_to_fr.translate"
+          STDERR.puts "usage example: rake translator FROM=en TO=fr DIR=\"config/locales\" PREFIX=activerecord FILE=en_to_fr.translate"
         end
         all_are_present
       end
@@ -170,7 +170,7 @@ module Translator
     end
 
     def path(locale)
-      File.expand_path("#{directory}/#{locale}.yml")
+      File.expand_path(File.join(directory, [Translator.prefix, locale, 'yml'].compact.join('.')))
     end
 
     def deflatten_keys(hash)


### PR DESCRIPTION
This will allow you to run the rake tasks as follows:

- rake app:translator:export_keys DIR="config/locales" FROM=nl TO=en PREFIX=activerecord
- rake app:translator:import_keys DIR="config/locales" FROM=nl TO=en PREFIX=activerecord
- This example will load 'config/locales/activerecord.nl.yml' and export missing keys
  to activerecord_translate_nl_to_en.txt